### PR TITLE
add Ubuntu prerequisites to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,12 @@ On Fedora (assuming PipeWire is already setup) these can be installed with:
 ```
 sudo dnf install pulseaudio-utils python3 python3-pyusb
 ```
+
+On Debian based systems (like Ubuntu) these can be installed with:
+```
+sudo apt install pulseaudio-utils python3 python3-usb
+```
+
 ### Install
 
 Clone this repo and cd into it


### PR DESCRIPTION
This PR adds setup steps for Debian based systems.
I think this is nice for the next user who wants to install it.

The only difference is the package manager and a different package name for pyusb